### PR TITLE
FOJALKA-21-Internal-implementation-of-an-automaton-run-on-a-given-word-Finite-automata-only

### DIFF
--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,10 +1,10 @@
-import {IEdge, RunCommand, ISimulation} from "../types.ts";
+import {RunCommand, ISimulation} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
-export class NextStepCommand extends RunCommand<IEdge> {
+export class NextStepCommand extends RunCommand {
 
-    constructor (_simulation: ISimulation<IEdge>){
+    constructor (_simulation: ISimulation){
         super (_simulation);
     }
 

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,13 +1,21 @@
-import {RunCommand} from "../types.ts";
+import {IEdge, RunCommand} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
-export class NextStepCommand extends RunCommand<number> {
+export class NextStepCommand extends RunCommand<IEdge> {
+
+    // creates new visitor, configuration accepts it, this simulates a step on the automata, saves the edge traversed into this.result
     execute(): IErrorMessage | undefined {
         this.saveBackup();
         const nextStepVisitor = new NextStepVisitor(this.simulation.automaton);
+
+        const oldState = this.simulation.configuration.stateId;
+
         this.simulation.configuration = this.simulation.configuration.accept(nextStepVisitor);
-        // TODO store the used edge into this.result. Get this info from the return value of accept probably.
+
+        const newState = this.simulation.configuration.stateId;
+        this.result = this.simulation.automaton.deltaFunctionMatrix[oldState][newState][0];
+
         return;
     }
 }

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,8 +1,12 @@
-import {IEdge, RunCommand} from "../types.ts";
+import {IEdge, RunCommand, ISimulation} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
 export class NextStepCommand extends RunCommand<IEdge> {
+
+    constructor (_simulation: ISimulation<IEdge>){
+        super (_simulation);
+    }
 
     // creates new visitor, configuration accepts it, this simulates a step on the automata, saves the edge traversed into this.result
     execute(): IErrorMessage | undefined {

--- a/src/types/factories.ts
+++ b/src/types/factories.ts
@@ -48,7 +48,7 @@ export class AbstractAutomatonFactory implements IAutomatonFactory {
 export class FiniteAutomatonFactory implements IAutomatonFactory {
     createAutomaton(initialStateId: string): IAutomaton {
         return new Automaton({
-            states: [],
+            states: [initialStateId],
             deltaFunctionMatrix: {},
             automatonType: AutomatonType.FINITE,
             initialStateId,
@@ -67,7 +67,7 @@ export class FiniteAutomatonFactory implements IAutomatonFactory {
 export class PDAFactory implements IAutomatonFactory {
     createAutomaton(initialStateId: string): IAutomaton {
         return new Automaton({
-            states: [],
+            states: [initialStateId],
             deltaFunctionMatrix: {},
             automatonType: AutomatonType.PDA,
             initialStateId,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -195,6 +195,7 @@ export class Simulation<T> implements ISimulation<T> {
         if (command.execute()) {
              this.commandHistory.push(command); 
             }
+        // maybe return error if fails to execute
     }
     undo(): void {
         const command = this.commandHistory.pop();
@@ -203,7 +204,7 @@ export class Simulation<T> implements ISimulation<T> {
     }
 
     run(): void {
-        
+        // TODO simulates the entire run of the word in configuration on the automata
     }
 
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -169,23 +169,52 @@ class PDAConfigurationMemento implements IConfigurationMemento {
     }
 }
 
-export interface ISimulation {
+export interface ISimulation<T> {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
 
-    commandHistory: RunCommand<unknown>[];
-    executeCommand<T>(command: RunCommand<T>): void; // if (command.execute()) { commandHistory.push(command); }
+    commandHistory: RunCommand<T>[];
+    executeCommand(command: RunCommand<T>): void; // if (command.execute()) { commandHistory.push(command); }
     undo(): void; // command = commandHistory.pop(); command.undo();
 
     run(): void;
 }
 
-export abstract class RunCommand<T = void> {
-    simulation: ISimulation;
+export class Simulation<T> implements ISimulation<T> {
+    automaton: IAutomaton;
+    configuration: IAutomatonConfiguration;
+    commandHistory: (RunCommand<T>)[];
+
+    constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration){
+            this.automaton = _automaton;
+            this.configuration = _configuration;
+            this.commandHistory = [];
+    }
+
+    executeCommand(command: RunCommand<T>): void {
+        if (command.execute()) {
+             this.commandHistory.push(command); 
+            }
+    }
+    undo(): void {
+        const command = this.commandHistory.pop();
+        if (command === undefined) return; // maybe error message when we try undo on empty history
+            else command.undo();
+    }
+
+    run(): void {
+        
+    }
+
+
+}
+
+export abstract class RunCommand<T> {
+    simulation: ISimulation<T>;
     backup?: IConfigurationMemento;
     result?: T;
 
-    protected constructor(_simulation: ISimulation) {
+    protected constructor(_simulation: ISimulation<T>) {
         this.simulation = _simulation;
     }
 

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -2,7 +2,8 @@ import {
     FiniteConfiguration,
     IAutomaton,
     IConfigurationVisitor,
-    PDAConfiguration
+    PDAConfiguration,
+    IEdge,
 } from "../types.ts";
 
 export class NextStepVisitor implements IConfigurationVisitor {
@@ -17,16 +18,19 @@ export class NextStepVisitor implements IConfigurationVisitor {
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
-        this.automaton.deltaFunctionMatrix[configuration.stateId].array.forEach(edge => {
+        let delta: Record<string, IEdge[]>;
+        delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
+        for (const key in delta){
+            const edge = delta[key][0];
             if (edge.inputChar == nextSymbol) nextState = edge.id
-        });
+        }
 
         if (nextState === undefined)    return configuration;
-                else {
-                    const t = this.automaton.deltaFunctionMatrix[configuration.stateId][nextState];
-                    return configuration
-                }
-
+            else {
+                let NewConfiguration: FiniteConfiguration;
+                NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
+                return NewConfiguration;
+            }
     };
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -3,8 +3,8 @@ import {
     IAutomaton,
     IConfigurationVisitor,
     PDAConfiguration,
-    IEdge,
 } from "../types.ts";
+
 
 export class NextStepVisitor implements IConfigurationVisitor {
     automaton: IAutomaton;
@@ -18,17 +18,15 @@ export class NextStepVisitor implements IConfigurationVisitor {
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
-        let delta: Record<string, IEdge[]>;
-        delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
+        const delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
         for (const key in delta){
             const edge = delta[key][0];
-            if (edge.inputChar == nextSymbol) nextState = edge.id
+            if (edge.inputChar == nextSymbol) nextState = key;
         }
 
         if (nextState === undefined)    return configuration;
             else {
-                let NewConfiguration: FiniteConfiguration;
-                NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
+                const NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
                 return NewConfiguration;
             }
     };

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -13,8 +13,9 @@ export class NextStepVisitor implements IConfigurationVisitor {
         this.automaton = _automaton;
     }
 
+    // Finite Automata visit command, preforms the next step command based on the finite configuration
+    // (which has currnet StateId and next symbol) and the FiniteAutomaton in this.automaton (using the deltaFunction)
     visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
-        // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for FA
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
@@ -30,6 +31,8 @@ export class NextStepVisitor implements IConfigurationVisitor {
                 return NewConfiguration;
             }
     };
+
+    
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA
         return configuration; // TODO remove, just a dummy return

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -14,9 +14,20 @@ export class NextStepVisitor implements IConfigurationVisitor {
 
     visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for FA
-        return configuration; // TODO remove, just a dummy return
-    };
+        const nextSymbol = configuration.remainingInput[0];
 
+        let nextState: string | undefined;
+        this.automaton.deltaFunctionMatrix[configuration.stateId].array.forEach(edge => {
+            if (edge.inputChar == nextSymbol) nextState = edge.id
+        });
+
+        if (nextState === undefined)    return configuration;
+                else {
+                    const t = this.automaton.deltaFunctionMatrix[configuration.stateId][nextState];
+                    return configuration
+                }
+
+    };
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA
         return configuration; // TODO remove, just a dummy return

--- a/tests/nextStepVisitor.test.ts
+++ b/tests/nextStepVisitor.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "vitest";
 import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, IEdge, Simulation} from "../src/types/types";
 import {AbstractAutomatonFactory} from "../src/types/factories";
 import { NextStepCommand } from "../src/types/commands/run";
-test("name", () =>{
+
+
+test("NextStepCommand/Visitor test", () =>{
     const factory = new AbstractAutomatonFactory ( AutomatonType.FINITE );
     
     const automaton = factory.createAutomaton("0");

--- a/tests/nextStepVisitor.test.ts
+++ b/tests/nextStepVisitor.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, IEdge, Simulation} from "../src/types/types";
+import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, Simulation} from "../src/types/types";
 import {AbstractAutomatonFactory} from "../src/types/factories";
 import { NextStepCommand } from "../src/types/commands/run";
 
@@ -18,7 +18,7 @@ test("NextStepCommand/Visitor test", () =>{
 
     const configuration = new FiniteConfiguration("0",["a","b","c"]);
 
-    const simulation = new Simulation<IEdge>(automaton, configuration);
+    const simulation = new Simulation(automaton, configuration);
     const command = new NextStepCommand(simulation);
     expect( simulation.configuration.stateId ).toBe("0");
     simulation.executeCommand(command );

--- a/tests/nextStepVisitor.test.ts
+++ b/tests/nextStepVisitor.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, IEdge, Simulation} from "../src/types/types";
+import {AbstractAutomatonFactory} from "../src/types/factories";
+import { NextStepCommand } from "../src/types/commands/run";
+test("name", () =>{
+    const factory = new AbstractAutomatonFactory ( AutomatonType.FINITE );
+    
+    const automaton = factory.createAutomaton("0");
+
+    expect(automaton.initialStateId).toBe("0");
+
+    automaton.deltaFunctionMatrix["0"] = {};
+    automaton.deltaFunctionMatrix["0"]["1"] = [];
+    automaton.deltaFunctionMatrix["0"]["1"].push( new FiniteAutomatonEdge("0", "a"));
+
+
+    const configuration = new FiniteConfiguration("0",["a","b","c"]);
+
+    const simulation = new Simulation<IEdge>(automaton, configuration);
+    const command = new NextStepCommand(simulation);
+    expect( simulation.configuration.stateId ).toBe("0");
+    simulation.executeCommand(command );
+    expect (command.result?.id).toBe("0");
+    expect( simulation.configuration.stateId ).toBe("1");
+
+});


### PR DESCRIPTION
implementoval som všetko potrebné na simuláciu nextStep/run na deterministických konečných automatoch:
- konkrétna trieda Simulation implements ISimulation , odstránil som ten generic v týchto triedach (aj v tých RunCommandoch), nevidím v tom velmi dôvod kedže to slúžilo len na tie resulty a tie budú len IEdge kedže v tej simulácii budú asi len krokové commandy. Ale aj keby to bolo niečo iné tak by som to tými genericsami určite neriešil, radšej nejakým dedením.
- run() na ISimmulation, volá nextStepCommand dokým neprejde celé slovo a vráti
true/false podľa toho či skončí v akceptačnom stave
- NextStepCommand.execute() spraví zavolá configuration.visit a výsledok uloží do result
- NextStepVisitor  samotná visit funkcia, spraví jeden krok na automate podla konfigurácie a vráti novú konfiguráciu
- test pre nextStep, či to vôbec funguje
- nejaké bugfixy a mierne zmeny ( factory aby začínala s počiatočným stavom v states, tie genericks som odstránil) 