### PR TITLE
Fojalka 21 internal implementation of an automaton run on a given word finite automata only

### DIFF
--- a/src/types/commands/edit.ts
+++ b/src/types/commands/edit.ts
@@ -24,6 +24,10 @@ export class AddEdgeCommand extends EditCommand {
             );
         }
 
+        if (this.automaton.deltaFunctionMatrix?.[this.fromStateId] === undefined) {
+            this.automaton.deltaFunctionMatrix[this.fromStateId] = {};
+        }
+
         if (this.automaton.deltaFunctionMatrix?.[this.fromStateId]?.[this.toStateId] === undefined) {
             this.automaton.deltaFunctionMatrix[this.fromStateId][this.toStateId] = [];
         }

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -9,7 +9,7 @@ export class NextStepCommand extends RunCommand {
     }
 
     // creates new visitor, configuration accepts it, this simulates a step on the automata, saves the edge traversed into this.result
-    execute(): IErrorMessage | undefined {
+    execute(): IErrorMessage | void {
         this.saveBackup();
         const nextStepVisitor = new NextStepVisitor(this.simulation.automaton);
 

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,10 +1,10 @@
-import {IEdge, RunCommand, ISimulation} from "../types.ts";
+import {RunCommand, ISimulation} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
-export class NextStepCommand extends RunCommand<IEdge> {
+export class NextStepCommand extends RunCommand {
 
-    constructor (_simulation: ISimulation<IEdge>){
+    constructor (_simulation: ISimulation){
         super (_simulation);
     }
 

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,13 +1,21 @@
-import {RunCommand} from "../types.ts";
+import {IEdge, RunCommand} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
-export class NextStepCommand extends RunCommand<number> {
+export class NextStepCommand extends RunCommand<IEdge> {
+
+    // creates new visitor, configuration accepts it, this simulates a step on the automata, saves the edge traversed into this.result
     execute(): IErrorMessage | undefined {
         this.saveBackup();
         const nextStepVisitor = new NextStepVisitor(this.simulation.automaton);
+
+        const oldState = this.simulation.configuration.stateId;
+
         this.simulation.configuration = this.simulation.configuration.accept(nextStepVisitor);
-        // TODO store the used edge into this.result. Get this info from the return value of accept probably.
+
+        const newState = this.simulation.configuration.stateId;
+        this.result = this.simulation.automaton.deltaFunctionMatrix[oldState][newState][0];
+
         return;
     }
 }

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -12,17 +12,11 @@ export class NextStepCommand extends RunCommand {
     execute(): IErrorMessage | void {
         this.saveBackup();
         const nextStepVisitor = new NextStepVisitor(this.simulation.automaton);
-        
-        const oldState = this.simulation.configuration.stateId;
-        const usedSymbol = this.simulation.configuration.remainingInput[0];
+
         this.simulation.configuration = this.simulation.configuration.accept(nextStepVisitor);
 
-        const newState = this.simulation.configuration.stateId;
-        
-        const edges = this.simulation.automaton.deltaFunctionMatrix[oldState][newState];
-        for(let i = 0; i< edges.length; i++){ 
-            if (edges[i].inputChar == usedSymbol) this.result = edges[i];
-        }
+        this.result = nextStepVisitor.result;
+    
         return;
     }
 }

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,8 +1,8 @@
-import {RunCommand, ISimulation} from "../types.ts";
+import {RunCommand, ISimulation, IEdge} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
-export class NextStepCommand extends RunCommand {
+export class NextStepCommand extends RunCommand<IEdge> {
 
     constructor (_simulation: ISimulation){
         super (_simulation);

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -12,14 +12,17 @@ export class NextStepCommand extends RunCommand {
     execute(): IErrorMessage | void {
         this.saveBackup();
         const nextStepVisitor = new NextStepVisitor(this.simulation.automaton);
-
+        
         const oldState = this.simulation.configuration.stateId;
-
+        const usedSymbol = this.simulation.configuration.remainingInput[0];
         this.simulation.configuration = this.simulation.configuration.accept(nextStepVisitor);
 
         const newState = this.simulation.configuration.stateId;
-        this.result = this.simulation.automaton.deltaFunctionMatrix[oldState][newState][0];
-
+        
+        const edges = this.simulation.automaton.deltaFunctionMatrix[oldState][newState];
+        for(let i = 0; i< edges.length; i++){ 
+            if (edges[i].inputChar == usedSymbol) this.result = edges[i];
+        }
         return;
     }
 }

--- a/src/types/commands/run.ts
+++ b/src/types/commands/run.ts
@@ -1,8 +1,12 @@
-import {IEdge, RunCommand} from "../types.ts";
+import {IEdge, RunCommand, ISimulation} from "../types.ts";
 import {IErrorMessage} from "../common.ts";
 import {NextStepVisitor} from "../visitors/configuration.ts";
 
 export class NextStepCommand extends RunCommand<IEdge> {
+
+    constructor (_simulation: ISimulation<IEdge>){
+        super (_simulation);
+    }
 
     // creates new visitor, configuration accepts it, this simulates a step on the automata, saves the edge traversed into this.result
     execute(): IErrorMessage | undefined {

--- a/src/types/factories.ts
+++ b/src/types/factories.ts
@@ -48,7 +48,7 @@ export class AbstractAutomatonFactory implements IAutomatonFactory {
 export class FiniteAutomatonFactory implements IAutomatonFactory {
     createAutomaton(initialStateId: string): IAutomaton {
         return new Automaton({
-            states: [],
+            states: [initialStateId],
             deltaFunctionMatrix: {},
             automatonType: AutomatonType.FINITE,
             initialStateId,
@@ -67,7 +67,7 @@ export class FiniteAutomatonFactory implements IAutomatonFactory {
 export class PDAFactory implements IAutomatonFactory {
     createAutomaton(initialStateId: string): IAutomaton {
         return new Automaton({
-            states: [],
+            states: [initialStateId],
             deltaFunctionMatrix: {},
             automatonType: AutomatonType.PDA,
             initialStateId,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -196,12 +196,12 @@ export class Simulation implements ISimulation {
     if (command.execute()) {
       this.commandHistory.push(command);
     }
-    // maybe return error if fails to execute
+
   }
   undo(): void {
     const command = this.commandHistory.pop();
     if (command === undefined) {
-      return; // maybe error message when we try undo on empty history
+      return;
     } else {
       command.undo();
     }
@@ -243,7 +243,7 @@ export abstract class RunCommand<T = void> {
     return this.result;
   }
 
-  abstract execute(): IErrorMessage | void; // this.saveBackup(); ...perform command...
+  abstract execute(): IErrorMessage | undefined; // this.saveBackup(); ...perform command...
 }
 
 export abstract class EditCommand<T = void> {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -184,7 +184,7 @@ export interface ISimulation {
 export class Simulation implements ISimulation {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
-    commandHistory: RunCommand<IEdge>[];
+    commandHistory: RunCommand<unknown>[];
 
     constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration) {
             this.automaton = _automaton;
@@ -192,7 +192,7 @@ export class Simulation implements ISimulation {
             this.commandHistory = [];
     }
 
-    executeCommand(command: RunCommand<IEdge>): void {
+    executeCommand(command: RunCommand<unknown>): void {
         if (command.execute()) {
             this.commandHistory.push(command); 
         }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,6 @@
 import {IErrorMessage} from "./common.ts";
 import {arraysEqual} from "../utils.ts";
-import { NextStepCommand } from "./commands/run";
+import {NextStepCommand} from "./commands/run";
 
 export enum AutomatonType {
     FINITE = "FINITE",
@@ -170,7 +170,7 @@ class PDAConfigurationMemento implements IConfigurationMemento {
     }
 }
 
-export interface ISimulation{
+export interface ISimulation {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
 
@@ -184,9 +184,9 @@ export interface ISimulation{
 export class Simulation implements ISimulation {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
-    commandHistory: (RunCommand)[];
+    commandHistory: RunCommand[];
 
-    constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration){
+    constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration) {
             this.automaton = _automaton;
             this.configuration = _configuration;
             this.commandHistory = [];
@@ -194,31 +194,30 @@ export class Simulation implements ISimulation {
 
     executeCommand(command: RunCommand): void {
         if (command.execute()) {
-             this.commandHistory.push(command); 
-            }
+            this.commandHistory.push(command); 
+        }
         // maybe return error if fails to execute
     }
     undo(): void {
         const command = this.commandHistory.pop();
-        if (command === undefined) return; // maybe error message when we try undo on empty history
-            else command.undo();
+        if (command === undefined) {
+            return; // maybe error message when we try undo on empty history
+        } else {
+            command.undo();
+        }
     }
 
     // simulates the entire run on the word in configuration (or the remaining word) and returns true if the
     // last state is accepting and false if it isn't
     run(): boolean {
-
         while(this.configuration.remainingInput.length>0){
             const nextCommand = new NextStepCommand(this);
             if (nextCommand.execute()) {
                 this.commandHistory.push(nextCommand); 
-               }
-        }
-        this.automaton.finalStateIds.forEach(element  => {if(element===this.configuration.stateId) return true; });
-        return false;
+            }
+        }   
+        return this.automaton.finalStateIds.some(finalStateId => this.configuration.stateId === finalStateId);
     }
-
-
 }
 
 export abstract class RunCommand {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -184,7 +184,7 @@ export interface ISimulation {
 export class Simulation implements ISimulation {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
-    commandHistory: RunCommand<unknown>[];
+    commandHistory: RunCommand<IEdge>[];
 
     constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration) {
             this.automaton = _automaton;
@@ -192,7 +192,7 @@ export class Simulation implements ISimulation {
             this.commandHistory = [];
     }
 
-    executeCommand(command: RunCommand): void {
+    executeCommand(command: RunCommand<IEdge>): void {
         if (command.execute()) {
             this.commandHistory.push(command); 
         }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -193,10 +193,10 @@ export class Simulation implements ISimulation {
   }
 
   executeCommand(command: RunCommand<unknown>): void {
-    if (command.execute()) {
+    if (command.execute() === undefined) {
       this.commandHistory.push(command);
     }
-
+    //TODO else if error respond to it
   }
   undo(): void {
     const command = this.commandHistory.pop();
@@ -212,9 +212,10 @@ export class Simulation implements ISimulation {
   run(): boolean {
     while (this.configuration.remainingInput.length > 0) {
       const nextCommand = new NextStepCommand(this);
-      if (nextCommand.execute()) {
+      if (nextCommand.execute() === undefined) {
         this.commandHistory.push(nextCommand);
       }
+      //TODO else if error respond to it
     }
     return this.automaton.finalStateIds.some(finalStateId => this.configuration.stateId === finalStateId);
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -195,6 +195,7 @@ export class Simulation<T> implements ISimulation<T> {
         if (command.execute()) {
              this.commandHistory.push(command); 
             }
+        // maybe return error if fails to execute
     }
     undo(): void {
         const command = this.commandHistory.pop();
@@ -203,7 +204,7 @@ export class Simulation<T> implements ISimulation<T> {
     }
 
     run(): void {
-        
+        // TODO simulates the entire run of the word in configuration on the automata
     }
 
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -174,8 +174,8 @@ export interface ISimulation {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
 
-    commandHistory: RunCommand[];
-    executeCommand(command: RunCommand): void; // if (command.execute()) { commandHistory.push(command); }
+    commandHistory: RunCommand<unknown>[];
+    executeCommand(command: RunCommand<unknown>): void; // if (command.execute()) { commandHistory.push(command); }
     undo(): void; // command = commandHistory.pop(); command.undo();
 
     run(): void;
@@ -184,7 +184,7 @@ export interface ISimulation {
 export class Simulation implements ISimulation {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
-    commandHistory: RunCommand[];
+    commandHistory: RunCommand<unknown>[];
 
     constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration) {
             this.automaton = _automaton;
@@ -220,10 +220,10 @@ export class Simulation implements ISimulation {
     }
 }
 
-export abstract class RunCommand {
+export abstract class RunCommand<T = void> {
     simulation: ISimulation;
     backup?: IConfigurationMemento;
-    result?: IEdge;
+    result?: T;
 
     protected constructor(_simulation: ISimulation) {
         this.simulation = _simulation;
@@ -239,7 +239,7 @@ export abstract class RunCommand {
         }
     }
 
-    getResult(): IEdge | undefined {
+    getResult(): T | undefined {
         return this.result;
     }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -169,23 +169,52 @@ class PDAConfigurationMemento implements IConfigurationMemento {
     }
 }
 
-export interface ISimulation {
+export interface ISimulation<T> {
     automaton: IAutomaton;
     configuration: IAutomatonConfiguration;
 
-    commandHistory: RunCommand<unknown>[];
-    executeCommand<T>(command: RunCommand<T>): void; // if (command.execute()) { commandHistory.push(command); }
+    commandHistory: RunCommand<T>[];
+    executeCommand(command: RunCommand<T>): void; // if (command.execute()) { commandHistory.push(command); }
     undo(): void; // command = commandHistory.pop(); command.undo();
 
     run(): void;
 }
 
-export abstract class RunCommand<T = void> {
-    simulation: ISimulation;
+export class Simulation<T> implements ISimulation<T> {
+    automaton: IAutomaton;
+    configuration: IAutomatonConfiguration;
+    commandHistory: (RunCommand<T>)[];
+
+    constructor(_automaton: IAutomaton, _configuration: IAutomatonConfiguration){
+            this.automaton = _automaton;
+            this.configuration = _configuration;
+            this.commandHistory = [];
+    }
+
+    executeCommand(command: RunCommand<T>): void {
+        if (command.execute()) {
+             this.commandHistory.push(command); 
+            }
+    }
+    undo(): void {
+        const command = this.commandHistory.pop();
+        if (command === undefined) return; // maybe error message when we try undo on empty history
+            else command.undo();
+    }
+
+    run(): void {
+        
+    }
+
+
+}
+
+export abstract class RunCommand<T> {
+    simulation: ISimulation<T>;
     backup?: IConfigurationMemento;
     result?: T;
 
-    protected constructor(_simulation: ISimulation) {
+    protected constructor(_simulation: ISimulation<T>) {
         this.simulation = _simulation;
     }
 

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -14,7 +14,19 @@ export class NextStepVisitor implements IConfigurationVisitor {
 
     visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for FA
-        return configuration; // TODO remove, just a dummy return
+        const nextSymbol = configuration.remainingInput[0];
+
+        let nextState: string | undefined;
+        this.automaton.deltaFunctionMatrix[configuration.stateId].array.forEach(edge => {
+            if (edge.inputChar == nextSymbol) nextState = edge.id
+        });
+
+        if (nextState === undefined)    return configuration;
+                else {
+                    const t = this.automaton.deltaFunctionMatrix[configuration.stateId][nextState];
+                    return configuration
+                }
+
     };
 
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -21,14 +21,16 @@ export class NextStepVisitor implements IConfigurationVisitor {
         let nextState: string | undefined;
         const delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
         for (const key in delta){
-            const edge = delta[key][0];
-            if (edge.inputChar == nextSymbol) nextState = key;
+            const edges = delta[key];
+            for(let i = 0; i< edges.length; i++){ 
+                if (edges[i].inputChar == nextSymbol) nextState = key;
+            }
         }
 
         if (nextState === undefined)    return configuration;
             else {
-                const NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
-                return NewConfiguration;
+                const newConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
+                return newConfiguration;
             }
     };
 

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -2,7 +2,8 @@ import {
     FiniteConfiguration,
     IAutomaton,
     IConfigurationVisitor,
-    PDAConfiguration
+    PDAConfiguration,
+    IEdge,
 } from "../types.ts";
 
 export class NextStepVisitor implements IConfigurationVisitor {
@@ -17,16 +18,19 @@ export class NextStepVisitor implements IConfigurationVisitor {
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
-        this.automaton.deltaFunctionMatrix[configuration.stateId].array.forEach(edge => {
+        let delta: Record<string, IEdge[]>;
+        delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
+        for (const key in delta){
+            const edge = delta[key][0];
             if (edge.inputChar == nextSymbol) nextState = edge.id
-        });
+        }
 
         if (nextState === undefined)    return configuration;
-                else {
-                    const t = this.automaton.deltaFunctionMatrix[configuration.stateId][nextState];
-                    return configuration
-                }
-
+            else {
+                let NewConfiguration: FiniteConfiguration;
+                NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
+                return NewConfiguration;
+            }
     };
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -27,7 +27,7 @@ export class NextStepVisitor implements IConfigurationVisitor {
     const delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
     for (const fromState in delta) {
       const edges = delta[fromState];
-      for (let i = 0; i < edges.length; i++) { 
+      for (let i = 0; i < edges.length; i++) {
         if (edges[i].inputChar == nextSymbol) {
           nextState = fromState;
           this.result = edges[i];

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -2,12 +2,14 @@ import {
     FiniteConfiguration,
     IAutomaton,
     IConfigurationVisitor,
+    IEdge,
     PDAConfiguration,
 } from "../types.ts";
 
 
 export class NextStepVisitor implements IConfigurationVisitor {
     automaton: IAutomaton;
+    result?: IEdge;
 
     constructor(_automaton: IAutomaton) {
         this.automaton = _automaton;
@@ -15,7 +17,11 @@ export class NextStepVisitor implements IConfigurationVisitor {
 
     // Finite Automata visit command, preforms the next step command based on the finite configuration
     // (which has currnet StateId and next symbol) and the FiniteAutomaton in this.automaton (using the deltaFunction)
+    // stores the edge traversed in this.result
     visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
+        if (configuration.remainingInput.length==0) {
+            return configuration;
+        }
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
@@ -23,7 +29,10 @@ export class NextStepVisitor implements IConfigurationVisitor {
         for (const fromState in delta){
             const edges = delta[fromState];
             for(let i = 0; i< edges.length; i++){ 
-                if (edges[i].inputChar == nextSymbol) nextState = fromState;
+                if (edges[i].inputChar == nextSymbol) {
+                    nextState = fromState;
+                    this.result = edges[i];
+                }
             }
         }
 

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -3,8 +3,8 @@ import {
     IAutomaton,
     IConfigurationVisitor,
     PDAConfiguration,
-    IEdge,
 } from "../types.ts";
+
 
 export class NextStepVisitor implements IConfigurationVisitor {
     automaton: IAutomaton;
@@ -18,17 +18,15 @@ export class NextStepVisitor implements IConfigurationVisitor {
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
-        let delta: Record<string, IEdge[]>;
-        delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
+        const delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
         for (const key in delta){
             const edge = delta[key][0];
-            if (edge.inputChar == nextSymbol) nextState = edge.id
+            if (edge.inputChar == nextSymbol) nextState = key;
         }
 
         if (nextState === undefined)    return configuration;
             else {
-                let NewConfiguration: FiniteConfiguration;
-                NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
+                const NewConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
                 return NewConfiguration;
             }
     };

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -27,11 +27,12 @@ export class NextStepVisitor implements IConfigurationVisitor {
             }
         }
 
-        if (nextState === undefined)    return configuration;
-            else {
-                const newConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
-                return newConfiguration;
-            }
+        if (nextState === undefined) {
+            return configuration;
+        } else {
+            const newConfiguration = new FiniteConfiguration(nextState, configuration.remainingInput.slice(1));
+            return newConfiguration;
+        }
     };
 
     

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -13,8 +13,9 @@ export class NextStepVisitor implements IConfigurationVisitor {
         this.automaton = _automaton;
     }
 
+    // Finite Automata visit command, preforms the next step command based on the finite configuration
+    // (which has currnet StateId and next symbol) and the FiniteAutomaton in this.automaton (using the deltaFunction)
     visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
-        // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for FA
         const nextSymbol = configuration.remainingInput[0];
 
         let nextState: string | undefined;
@@ -30,6 +31,8 @@ export class NextStepVisitor implements IConfigurationVisitor {
                 return NewConfiguration;
             }
     };
+
+    
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA
         return configuration; // TODO remove, just a dummy return

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -18,7 +18,7 @@ export class NextStepVisitor implements IConfigurationVisitor {
   // (which has currnet StateId and next symbol) and the FiniteAutomaton in this.automaton (using the deltaFunction)
   // stores the edge traversed in this.result
   visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
-    if (configuration.remainingInput.length == 0) {
+    if (configuration.remainingInput.length === 0) {
       return configuration;
     }
     const nextSymbol = configuration.remainingInput[0];
@@ -28,7 +28,7 @@ export class NextStepVisitor implements IConfigurationVisitor {
     for (const fromState in delta) {
       const edges = delta[fromState];
       for (let i = 0; i < edges.length; i++) {
-        if (edges[i].inputChar == nextSymbol) {
+        if (edges[i].inputChar === nextSymbol) {
           nextState = fromState;
           this.result = edges[i];
         }

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -20,10 +20,10 @@ export class NextStepVisitor implements IConfigurationVisitor {
 
         let nextState: string | undefined;
         const delta = this.automaton.deltaFunctionMatrix[configuration.stateId];
-        for (const key in delta){
-            const edges = delta[key];
+        for (const fromState in delta){
+            const edges = delta[fromState];
             for(let i = 0; i< edges.length; i++){ 
-                if (edges[i].inputChar == nextSymbol) nextState = key;
+                if (edges[i].inputChar == nextSymbol) nextState = fromState;
             }
         }
 

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -14,9 +14,20 @@ export class NextStepVisitor implements IConfigurationVisitor {
 
     visitFiniteConfiguration(configuration: FiniteConfiguration): FiniteConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for FA
-        return configuration; // TODO remove, just a dummy return
-    };
+        const nextSymbol = configuration.remainingInput[0];
 
+        let nextState: string | undefined;
+        this.automaton.deltaFunctionMatrix[configuration.stateId].array.forEach(edge => {
+            if (edge.inputChar == nextSymbol) nextState = edge.id
+        });
+
+        if (nextState === undefined)    return configuration;
+                else {
+                    const t = this.automaton.deltaFunctionMatrix[configuration.stateId][nextState];
+                    return configuration
+                }
+
+    };
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA
         return configuration; // TODO remove, just a dummy return

--- a/src/types/visitors/configuration.ts
+++ b/src/types/visitors/configuration.ts
@@ -28,7 +28,6 @@ export class NextStepVisitor implements IConfigurationVisitor {
                 }
 
     };
-
     visitPDAConfiguration(configuration: PDAConfiguration): PDAConfiguration {
         // TODO implement: Based on this.automaton and configuration, calculate the next step configuration for PDA
         return configuration; // TODO remove, just a dummy return

--- a/tests/nextStep.test.ts
+++ b/tests/nextStep.test.ts
@@ -4,7 +4,7 @@ import {AbstractAutomatonFactory} from "../src/types/factories";
 import { NextStepCommand } from "../src/types/commands/run";
 
 
-test("NextStepCommand/Visitor test", () =>{
+test("nextStepCommand Visitor test", () =>{
     const factory = new AbstractAutomatonFactory ( AutomatonType.FINITE );
     
     const automaton = factory.createAutomaton("0");

--- a/tests/nextStep.test.ts
+++ b/tests/nextStep.test.ts
@@ -12,9 +12,9 @@ test("nextStepCommand Visitor test", () =>{
   expect(automaton.initialStateId).toBe("0");
 
   const addState = new AddStateCommand(automaton, "1");
-  addState.execute();
+  automaton.executeCommand(addState);
   const addEdge = new AddEdgeCommand(automaton, "0", "1", new FiniteAutomatonEdge("0", "a"));
-  addEdge.execute();
+  automaton.executeCommand(addEdge);
 
   const configuration = new FiniteConfiguration("0", ["a", "b", "c"]);
 

--- a/tests/nextStep.test.ts
+++ b/tests/nextStep.test.ts
@@ -1,29 +1,28 @@
-import {expect, test} from "vitest";
-import {NextStepCommand} from "../src/types/commands/run";
-import {AddEdgeCommand, AddStateCommand} from "../src/types/commands/edit";
-import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, Simulation} from "../src/types/types";
-import {AbstractAutomatonFactory} from "../src/types/factories";
-
+import { expect, test } from "vitest";
+import { NextStepCommand } from "../src/types/commands/run";
+import { AddEdgeCommand, AddStateCommand } from "../src/types/commands/edit";
+import { AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, Simulation } from "../src/types/types";
+import { AbstractAutomatonFactory } from "../src/types/factories";
 
 test("nextStepCommand Visitor test", () =>{
-    const factory = new AbstractAutomatonFactory(AutomatonType.FINITE);
-    
-    const automaton = factory.createAutomaton("0");
+  const factory = new AbstractAutomatonFactory(AutomatonType.FINITE);
 
-    expect(automaton.initialStateId).toBe("0");
+  const automaton = factory.createAutomaton("0");
 
-    const addState = new AddStateCommand(automaton, "1");
-    addState.execute();
-    const addEdge = new AddEdgeCommand(automaton, "0", "1", new FiniteAutomatonEdge("0", "a"));
-    addEdge.execute();
+  expect(automaton.initialStateId).toBe("0");
 
-    const configuration = new FiniteConfiguration("0",["a","b","c"]);
+  const addState = new AddStateCommand(automaton, "1");
+  addState.execute();
+  const addEdge = new AddEdgeCommand(automaton, "0", "1", new FiniteAutomatonEdge("0", "a"));
+  addEdge.execute();
 
-    const simulation = new Simulation(automaton, configuration);
-    const command = new NextStepCommand(simulation);
-    expect(simulation.configuration.stateId).toBe("0");
-    simulation.executeCommand(command);
-    expect (command.result?.id).toBe("0");
-    expect (simulation.configuration.stateId).toBe("1");
+  const configuration = new FiniteConfiguration("0", ["a", "b", "c"]);
+
+  const simulation = new Simulation(automaton, configuration);
+  const command = new NextStepCommand(simulation);
+  expect(simulation.configuration.stateId).toBe("0");
+  simulation.executeCommand(command);
+  expect (command.result?.id).toBe("0");
+  expect (simulation.configuration.stateId).toBe("1");
 
 });

--- a/tests/nextStep.test.ts
+++ b/tests/nextStep.test.ts
@@ -23,7 +23,7 @@ test("nextStepCommand Visitor test", () =>{
     const command = new NextStepCommand(simulation);
     expect(simulation.configuration.stateId).toBe("0");
     simulation.executeCommand(command);
-    //expect (command.result?.id).toBe("0");
-    //expect (simulation.configuration.stateId).toBe("1");
+    expect (command.result?.id).toBe("0");
+    expect (simulation.configuration.stateId).toBe("1");
 
 });

--- a/tests/nextStep.test.ts
+++ b/tests/nextStep.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
+import { NextStepCommand } from "../src/types/commands/run";
 import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, Simulation} from "../src/types/types";
 import {AbstractAutomatonFactory} from "../src/types/factories";
-import { NextStepCommand } from "../src/types/commands/run";
+
 
 
 test("nextStepCommand Visitor test", () =>{

--- a/tests/nextStep.test.ts
+++ b/tests/nextStep.test.ts
@@ -1,29 +1,29 @@
-import { expect, test } from "vitest";
-import { NextStepCommand } from "../src/types/commands/run";
+import {expect, test} from "vitest";
+import {NextStepCommand} from "../src/types/commands/run";
+import {AddEdgeCommand, AddStateCommand} from "../src/types/commands/edit";
 import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, Simulation} from "../src/types/types";
 import {AbstractAutomatonFactory} from "../src/types/factories";
 
 
-
 test("nextStepCommand Visitor test", () =>{
-    const factory = new AbstractAutomatonFactory ( AutomatonType.FINITE );
+    const factory = new AbstractAutomatonFactory(AutomatonType.FINITE);
     
     const automaton = factory.createAutomaton("0");
 
     expect(automaton.initialStateId).toBe("0");
 
-    automaton.deltaFunctionMatrix["0"] = {};
-    automaton.deltaFunctionMatrix["0"]["1"] = [];
-    automaton.deltaFunctionMatrix["0"]["1"].push( new FiniteAutomatonEdge("0", "a"));
-
+    const addState = new AddStateCommand(automaton, "1");
+    addState.execute();
+    const addEdge = new AddEdgeCommand(automaton, "0", "1", new FiniteAutomatonEdge("0", "a"));
+    addEdge.execute();
 
     const configuration = new FiniteConfiguration("0",["a","b","c"]);
 
     const simulation = new Simulation(automaton, configuration);
     const command = new NextStepCommand(simulation);
-    expect( simulation.configuration.stateId ).toBe("0");
-    simulation.executeCommand(command );
-    expect (command.result?.id).toBe("0");
-    expect( simulation.configuration.stateId ).toBe("1");
+    expect(simulation.configuration.stateId).toBe("0");
+    simulation.executeCommand(command);
+    //expect (command.result?.id).toBe("0");
+    //expect (simulation.configuration.stateId).toBe("1");
 
 });

--- a/tests/nextStepVisitor.test.ts
+++ b/tests/nextStepVisitor.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "vitest";
 import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, IEdge, Simulation} from "../src/types/types";
 import {AbstractAutomatonFactory} from "../src/types/factories";
 import { NextStepCommand } from "../src/types/commands/run";
-test("name", () =>{
+
+
+test("NextStepCommand/Visitor test", () =>{
     const factory = new AbstractAutomatonFactory ( AutomatonType.FINITE );
     
     const automaton = factory.createAutomaton("0");

--- a/tests/nextStepVisitor.test.ts
+++ b/tests/nextStepVisitor.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, IEdge, Simulation} from "../src/types/types";
+import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, Simulation} from "../src/types/types";
 import {AbstractAutomatonFactory} from "../src/types/factories";
 import { NextStepCommand } from "../src/types/commands/run";
 
@@ -18,7 +18,7 @@ test("NextStepCommand/Visitor test", () =>{
 
     const configuration = new FiniteConfiguration("0",["a","b","c"]);
 
-    const simulation = new Simulation<IEdge>(automaton, configuration);
+    const simulation = new Simulation(automaton, configuration);
     const command = new NextStepCommand(simulation);
     expect( simulation.configuration.stateId ).toBe("0");
     simulation.executeCommand(command );

--- a/tests/nextStepVisitor.test.ts
+++ b/tests/nextStepVisitor.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import {AutomatonType, FiniteAutomatonEdge, FiniteConfiguration, IEdge, Simulation} from "../src/types/types";
+import {AbstractAutomatonFactory} from "../src/types/factories";
+import { NextStepCommand } from "../src/types/commands/run";
+test("name", () =>{
+    const factory = new AbstractAutomatonFactory ( AutomatonType.FINITE );
+    
+    const automaton = factory.createAutomaton("0");
+
+    expect(automaton.initialStateId).toBe("0");
+
+    automaton.deltaFunctionMatrix["0"] = {};
+    automaton.deltaFunctionMatrix["0"]["1"] = [];
+    automaton.deltaFunctionMatrix["0"]["1"].push( new FiniteAutomatonEdge("0", "a"));
+
+
+    const configuration = new FiniteConfiguration("0",["a","b","c"]);
+
+    const simulation = new Simulation<IEdge>(automaton, configuration);
+    const command = new NextStepCommand(simulation);
+    expect( simulation.configuration.stateId ).toBe("0");
+    simulation.executeCommand(command );
+    expect (command.result?.id).toBe("0");
+    expect( simulation.configuration.stateId ).toBe("1");
+
+});


### PR DESCRIPTION
implementoval som všetko potrebné na simuláciu nextStep/run na deterministických konečných automatoch:
- konkrétna trieda Simulation implements ISimulation , odstránil som ten generic v týchto triedach (aj v tých RunCommandoch), nevidím v tom velmi dôvod kedže to slúžilo len na tie resulty a tie budú len IEdge kedže v tej simulácii budú asi len krokové commandy. Ale aj keby to bolo niečo iné tak by som to tými genericsami určite neriešil, radšej nejakým dedením.
- run() na ISimmulation, volá nextStepCommand dokým neprejde celé slovo a vráti
true/false podľa toho či skončí v akceptačnom stave
- NextStepCommand.execute() spraví zavolá configuration.visit a výsledok uloží do result
- NextStepVisitor  samotná visit funkcia, spraví jeden krok na automate podla konfigurácie a vráti novú konfiguráciu
- nejaký test pre nextStep, či to vôbec funguje, (už by aj test mal fungovať)
- nejaký bugfixy mierne zmeny ( factory aby začínala s počiatočným stavom v states, tie genericks som odstránil) 
