### PR TITLE
Fojalka 43 remove epsilon transitions algorithm

### DIFF
--- a/src/engine/algorithm.ts
+++ b/src/engine/algorithm.ts
@@ -213,6 +213,8 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
   outputType: AlgorithmParams = { Kind: Kind.AUTOMATON, AutomatonType: AutomatonType.FINITE };
 
   inputCore: AutomatonCore;
+
+  //only for the mode in init, so it wont be unused variable
   outputCore?: AutomatonCore;
 
   results?: AlgorithmResult[];
@@ -231,6 +233,8 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
     } else {
       this.results = [];
     }
+
+    //TODO - we need to decide if we want this or we always want second window
     this.outputCore = new AutomatonCore(AutomatonType.FINITE, SECONDARY_CYTOSCAPE_ID, mode);
 
     return undefined;
@@ -311,7 +315,7 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
       }
     }
 
-    //addind transitions to states expept initial state
+    //addind transitions from states except the initial state
     for (const state of this.inputCore.automaton.states) {
       if (state !== initial) {
         for (const symbol of alphabet) {
@@ -331,7 +335,7 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
       }
     }
 
-    //adding transitions to initial state
+    //adding transitions from the initial state
     for (const symbol of alphabet) {
       for (const state of epsilonTails[initial]) {
         const endStates = this.getEndStates(state, symbol, epsilonTails);
@@ -349,7 +353,7 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
       }
     }
 
-    //setting initial state as final if it has final state in epsilon tail
+    //setting initial state as final if it has final state in its epsilon tail
     if (epsilonTails[initial].some(state => this.inputCore.automaton.finalStateIds.includes(state))) {
       const command = new SetStateFinalFlagCommand(this.inputCore.automaton, initial, true);
       this.results.push({ highlight: [], command: command });

--- a/src/engine/algorithm.ts
+++ b/src/engine/algorithm.ts
@@ -264,8 +264,10 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
   precomputeResults() {
     this.results = [];
     const epsilonTails: Record<string, string[]> = {};
-    const delta = this.inputCore.automaton.deltaFunctionMatrix;
     const addedEdges: string[][] = [];
+    
+    const delta = this.inputCore.automaton.deltaFunctionMatrix;
+    const initial = this.inputCore.automaton.initialStateId;
 
     //computing epsilon tails for all states
     const stack: string[] = [];
@@ -311,7 +313,7 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
 
     //addind transitions to states expept initial state
     for (const state of this.inputCore.automaton.states) {
-      if (state !== this.inputCore.automaton.initialStateId) {
+      if (state !== initial) {
         for (const symbol of alphabet) {
           const endStates = this.getEndStates(state, symbol, epsilonTails);
 
@@ -331,16 +333,16 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
 
     //adding transitions to initial state
     for (const symbol of alphabet) {
-      for (const state of epsilonTails[this.inputCore.automaton.initialStateId]) {
+      for (const state of epsilonTails[initial]) {
         const endStates = this.getEndStates(state, symbol, epsilonTails);
 
         for (const newState of endStates) {
-          if (delta[this.inputCore.automaton.initialStateId][newState] === undefined || !delta[this.inputCore.automaton.initialStateId][newState].some(edge => edge.inputChar === symbol)) {
-            if (!addedEdges.some(edge => edge[0] === this.inputCore.automaton.initialStateId && edge[1] === newState && edge[2] === symbol)) {
+          if (delta[initial][newState] === undefined || !delta[initial][newState].some(edge => edge.inputChar === symbol)) {
+            if (!addedEdges.some(edge => edge[0] === initial && edge[1] === newState && edge[2] === symbol)) {
               const edge = this.inputCore.createEdge({ id: "", inputChar: symbol });
-              const command = new AddEdgeCommand(this.inputCore.automaton, this.inputCore.automaton.initialStateId, newState, edge);
+              const command = new AddEdgeCommand(this.inputCore.automaton, initial, newState, edge);
               this.results.push({ highlight: [], command: command });
-              addedEdges.push([this.inputCore.automaton.initialStateId, newState, symbol]);
+              addedEdges.push([initial, newState, symbol]);
             }
           }
         }
@@ -348,8 +350,8 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
     }
 
     //setting initial state as final if it has final state in epsilon tail
-    if (epsilonTails[this.inputCore.automaton.initialStateId].some(state => this.inputCore.automaton.finalStateIds.includes(state))) {
-      const command = new SetStateFinalFlagCommand(this.inputCore.automaton, this.inputCore.automaton.initialStateId, true);
+    if (epsilonTails[initial].some(state => this.inputCore.automaton.finalStateIds.includes(state))) {
+      const command = new SetStateFinalFlagCommand(this.inputCore.automaton, initial, true);
       this.results.push({ highlight: [], command: command });
     }
   }

--- a/src/engine/algorithm.ts
+++ b/src/engine/algorithm.ts
@@ -265,7 +265,7 @@ export class RemoveEpsilonAlgorithm implements IAlgorithm {
     this.results = [];
     const epsilonTails: Record<string, string[]> = {};
     const addedEdges: string[][] = [];
-    
+
     const delta = this.inputCore.automaton.deltaFunctionMatrix;
     const initial = this.inputCore.automaton.initialStateId;
 

--- a/tests/nondeterministicToDeterministic.test.ts
+++ b/tests/nondeterministicToDeterministic.test.ts
@@ -118,21 +118,14 @@ test("testing algorithm functions", () => {
 
   //second algorithm for testing undo() function
   const algorithm2 = new NondeterministicToDeterministicAlgorithm(core);
-  const core3 = new AutomatonCore(AutomatonType.FINITE, "test_core2", new ModeHolder());
-  core3.automaton = new Automaton({
-    states: ["q0", "q1"],
-    deltaFunctionMatrix: { "q0":{ "q1":[new FiniteAutomatonEdge("1", "a")] } },
-    automatonType: AutomatonType.FINITE,
-    initialStateId: "q0",
-    finalStateIds: ["q1"] });
-  const core4 = algorithm2.init(new ModeHolder);
-  expect(core4).toBeInstanceOf(AutomatonCore);
+  const core3 = algorithm2.init(new ModeHolder);
+  expect(core3).toBeInstanceOf(AutomatonCore);
 
   //testing if next + undo equals the original automaton
   const result1 = algorithm.next();
   core2.automaton.executeCommand((result1?.command as AutomatonEditCommand));
   algorithm.undo();
-  expect(core2.automaton).toEqual(core4.automaton);
+  expect(core2.automaton).toEqual(core3.automaton);
 
   //testing if next + undo + next return the same command as next
   const result2 = algorithm.next();
@@ -145,16 +138,16 @@ test("testing algorithm functions", () => {
   core2.automaton.executeCommand((algorithm.next()?.command as AutomatonEditCommand));
   algorithm.undo();
   algorithm.undo();
-  expect(core2.automaton).toEqual(core4.automaton);
+  expect(core2.automaton).toEqual(core3.automaton);
 
   //testing if next + undo works in the entire algorthm
   for (let i = 0; i < algorithm.results.length - 1; i++) {
     core2.automaton.executeCommand((algorithm.next()?.command as AutomatonEditCommand));
-    core4.automaton.executeCommand((algorithm2.next()?.command as AutomatonEditCommand));
-    expect(core2.automaton).toEqual(core4.automaton);
+    core3.automaton.executeCommand((algorithm2.next()?.command as AutomatonEditCommand));
+    expect(core2.automaton).toEqual(core3.automaton);
 
     core2.automaton.executeCommand((algorithm.next()?.command as AutomatonEditCommand));
     algorithm.undo();
-    expect(core2.automaton).toEqual(core4.automaton);
+    expect(core2.automaton).toEqual(core3.automaton);
   }
 });

--- a/tests/removeEpsilon.test.ts
+++ b/tests/removeEpsilon.test.ts
@@ -107,57 +107,57 @@ test("testing algorithm functions", () => {
 });
 
 test("testing algorithm corectness", () => {
-    const core = new AutomatonCore(AutomatonType.FINITE, "test_core", new ModeHolder());
-    const algorithm = new RemoveEpsilonAlgorithm(core);
-  
-    core.automaton = new Automaton({
-      states: ["q0", "q1", "q2", "q3"],
-      deltaFunctionMatrix: {
-        "q0":{ "q1":[new FiniteAutomatonEdge("1", EPSILON)], "q3":[new FiniteAutomatonEdge("2", "a"), new FiniteAutomatonEdge("3", "b")] },
-        "q1":{ "q1":[new FiniteAutomatonEdge("3", "b")], "q2":[new FiniteAutomatonEdge("4", "a")] },
-        "q2":{ "q0":[new FiniteAutomatonEdge("5", EPSILON)] }
-      },
-      automatonType: AutomatonType.FINITE,
-      initialStateId: "q0",
-      finalStateIds: ["q1", "q3"]
-    });
+  const core = new AutomatonCore(AutomatonType.FINITE, "test_core", new ModeHolder());
+  const algorithm = new RemoveEpsilonAlgorithm(core);
 
-    algorithm.init(new ModeHolder());
-
-    //running the algorithm
-    let result = algorithm.next();
-    while (result !== undefined) {
-      core.automaton.executeCommand((result.command as AutomatonEditCommand));
-      result = algorithm.next();
-    }
-
-    //testing properities of the new automaton
-    expect(core.automaton.states).toEqual(["q0", "q1", "q2", "q3"]);
-    expect(core.automaton.finalStateIds).toEqual(["q1", "q3", "q0"]);
-    expect(core.automaton.initialStateId).toBe("q0");
-    expect(core.automaton.automatonType).toBe(AutomatonType.FINITE);
-
-    expect(algorithm.hasEpsilonTransitions()).toBeFalsy();
-
-    for (const state of ["q0", "q2"]){
-      expect(core.automaton.deltaFunctionMatrix["q0"][state]).toHaveLength(1);
-      expect(core.automaton.deltaFunctionMatrix["q0"][state][0].inputChar).toBe("a");
-    }
-    for (const state of ["q1", "q3"]){
-      expect(core.automaton.deltaFunctionMatrix["q0"][state]).toHaveLength(2);
-      expect(core.automaton.deltaFunctionMatrix["q0"][state][0].inputChar).toBeOneOf(["a", "b"]);
-      expect(core.automaton.deltaFunctionMatrix["q0"][state][1].inputChar).toBeOneOf(["a", "b"]);  
-    }
-
-    for (const state of ["q0", "q2"]){
-        expect(core.automaton.deltaFunctionMatrix["q1"][state]).toHaveLength(1);
-        expect(core.automaton.deltaFunctionMatrix["q1"][state][0].inputChar).toBe("a");
-    }
-    expect(core.automaton.deltaFunctionMatrix["q1"]["q1"]).toHaveLength(2);
-    expect(core.automaton.deltaFunctionMatrix["q1"]["q1"][0].inputChar).toBeOneOf(["a", "b"]);
-    expect(core.automaton.deltaFunctionMatrix["q1"]["q1"][1].inputChar).toBeOneOf(["a", "b"]);
-    expect(core.automaton.deltaFunctionMatrix["q1"]["q3"]).toBeUndefined();
-
-    expect(core.automaton.deltaFunctionMatrix["q2"]).toEqual({"q0":[]});
-    expect(core.automaton.deltaFunctionMatrix["q3"]).toBeUndefined();
+  core.automaton = new Automaton({
+    states: ["q0", "q1", "q2", "q3"],
+    deltaFunctionMatrix: {
+      "q0":{ "q1":[new FiniteAutomatonEdge("1", EPSILON)], "q3":[new FiniteAutomatonEdge("2", "a"), new FiniteAutomatonEdge("3", "b")] },
+      "q1":{ "q1":[new FiniteAutomatonEdge("3", "b")], "q2":[new FiniteAutomatonEdge("4", "a")] },
+      "q2":{ "q0":[new FiniteAutomatonEdge("5", EPSILON)] }
+    },
+    automatonType: AutomatonType.FINITE,
+    initialStateId: "q0",
+    finalStateIds: ["q1", "q3"]
   });
+
+  algorithm.init(new ModeHolder());
+
+  //running the algorithm
+  let result = algorithm.next();
+  while (result !== undefined) {
+    core.automaton.executeCommand((result.command as AutomatonEditCommand));
+    result = algorithm.next();
+  }
+
+  //testing properities of the new automaton
+  expect(core.automaton.states).toEqual(["q0", "q1", "q2", "q3"]);
+  expect(core.automaton.finalStateIds).toEqual(["q1", "q3", "q0"]);
+  expect(core.automaton.initialStateId).toBe("q0");
+  expect(core.automaton.automatonType).toBe(AutomatonType.FINITE);
+
+  expect(algorithm.hasEpsilonTransitions()).toBeFalsy();
+
+  for (const state of ["q0", "q2"]) {
+    expect(core.automaton.deltaFunctionMatrix["q0"][state]).toHaveLength(1);
+    expect(core.automaton.deltaFunctionMatrix["q0"][state][0].inputChar).toBe("a");
+  }
+  for (const state of ["q1", "q3"]) {
+    expect(core.automaton.deltaFunctionMatrix["q0"][state]).toHaveLength(2);
+    expect(core.automaton.deltaFunctionMatrix["q0"][state][0].inputChar).toBeOneOf(["a", "b"]);
+    expect(core.automaton.deltaFunctionMatrix["q0"][state][1].inputChar).toBeOneOf(["a", "b"]);
+  }
+
+  for (const state of ["q0", "q2"]) {
+    expect(core.automaton.deltaFunctionMatrix["q1"][state]).toHaveLength(1);
+    expect(core.automaton.deltaFunctionMatrix["q1"][state][0].inputChar).toBe("a");
+  }
+  expect(core.automaton.deltaFunctionMatrix["q1"]["q1"]).toHaveLength(2);
+  expect(core.automaton.deltaFunctionMatrix["q1"]["q1"][0].inputChar).toBeOneOf(["a", "b"]);
+  expect(core.automaton.deltaFunctionMatrix["q1"]["q1"][1].inputChar).toBeOneOf(["a", "b"]);
+  expect(core.automaton.deltaFunctionMatrix["q1"]["q3"]).toBeUndefined();
+
+  expect(core.automaton.deltaFunctionMatrix["q2"]).toEqual({ "q0":[] });
+  expect(core.automaton.deltaFunctionMatrix["q3"]).toBeUndefined();
+});

--- a/tests/removeEpsilon.test.ts
+++ b/tests/removeEpsilon.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "vitest";
+import { RemoveEpsilonAlgorithm } from "../src/engine/algorithm";
+import { AutomatonCore } from "../src/core/automatonCore";
+import { Automaton, AutomatonType } from "../src/engine/automaton/automaton";
+import { ModeHolder } from "../src/core/core";
+import { FiniteAutomatonEdge } from "../src/engine/automaton/edge";
+import { ErrorMessage } from "../src/engine/common";
+import { EPSILON } from "../src/constants";
+import { AutomatonEditCommand } from "../src/engine/automaton/commands/edit";
+
+test("testing algorithm functions", () => {
+  //testing error throwing on wrong inputs
+  let core = new AutomatonCore(AutomatonType.PDA, "test_core", new ModeHolder());
+  let algorithm = new RemoveEpsilonAlgorithm(core);
+
+  expect(algorithm.inputCore).toBe(core);
+  expect(algorithm.results).toBeUndefined();
+  expect(algorithm.index).toBe(0);
+  expect(() => algorithm.init(new ModeHolder)).toThrowError("Cannot use algorithm, as it only works with finite automata.");
+
+  core = new AutomatonCore(AutomatonType.FINITE, "test_core", new ModeHolder());
+  algorithm = new RemoveEpsilonAlgorithm(core);
+
+  core.automaton = new Automaton({
+    states: ["q0", "q1", "q2"],
+    deltaFunctionMatrix: {
+      "q0":{ "q1":[new FiniteAutomatonEdge("1", "a")], "q2":[new FiniteAutomatonEdge("2", "b")] },
+      "q1":{ "q1":[new FiniteAutomatonEdge("3", "a"), new FiniteAutomatonEdge("4", "b")] },
+      "q2":{ "q0":[new FiniteAutomatonEdge("5", "a")], "q2":[new FiniteAutomatonEdge("6", "b")] }
+    },
+    automatonType: AutomatonType.FINITE,
+    initialStateId: "q0",
+    finalStateIds: ["q1"]
+  });
+
+  //testing usage of next()/undo() before init()
+  expect(() => algorithm.next()).toThrowError("Cannot simulate algorithm step before start.");
+  let message = algorithm.undo();
+  expect(message).toEqual(new ErrorMessage("Cannot undo algorithm step before start."));
+
+  algorithm.init(new ModeHolder);
+  expect(algorithm.results).toEqual([]);
+
+  //testing usage of undo() before next()
+  message = algorithm.undo();
+  expect(message).toEqual(new ErrorMessage("There is nothing to undo."));
+
+  expect(algorithm.next()).toBeUndefined();
+
+  //second algorithm for testing undo() function
+  const core2 = new AutomatonCore(AutomatonType.FINITE, "test_core2", new ModeHolder());
+  const algorithm2 = new RemoveEpsilonAlgorithm(core2);
+  core.automaton = new Automaton({
+    states: ["q0", "q1", "q2"],
+    deltaFunctionMatrix: {
+      "q0":{ "q1":[new FiniteAutomatonEdge("1", EPSILON)], "q2":[new FiniteAutomatonEdge("2", "b")] },
+      "q1":{ "q1":[new FiniteAutomatonEdge("3", "a"), new FiniteAutomatonEdge("4", "b")], "q2":[new FiniteAutomatonEdge("5", EPSILON)] },
+      "q2":{ "q0":[new FiniteAutomatonEdge("6", "a")], "q2":[new FiniteAutomatonEdge("7", "b")] }
+    },
+    automatonType: AutomatonType.FINITE,
+    initialStateId: "q0",
+    finalStateIds: ["q1"]
+  });
+  core2.automaton = new Automaton({
+    states: ["q0", "q1", "q2"],
+    deltaFunctionMatrix: {
+      "q0":{ "q1":[new FiniteAutomatonEdge("1", EPSILON)], "q2":[new FiniteAutomatonEdge("2", "b")] },
+      "q1":{ "q1":[new FiniteAutomatonEdge("3", "a"), new FiniteAutomatonEdge("4", "b")], "q2":[new FiniteAutomatonEdge("5", EPSILON)] },
+      "q2":{ "q0":[new FiniteAutomatonEdge("6", "a")], "q2":[new FiniteAutomatonEdge("7", "b")] }
+    },
+    automatonType: AutomatonType.FINITE,
+    initialStateId: "q0",
+    finalStateIds: ["q1"]
+  });
+  algorithm.init(new ModeHolder());
+  algorithm2.init(new ModeHolder());
+
+  //testing if next + undo equals the original automaton
+  const result1 = algorithm.next();
+  core.automaton.executeCommand((result1?.command as AutomatonEditCommand));
+  algorithm.undo();
+  expect(core2.automaton).toEqual(core.automaton);
+
+  //testing if next + undo + next return the same command as next
+  const result2 = algorithm.next();
+  core.automaton.executeCommand((result2?.command as AutomatonEditCommand));
+  algorithm.undo();
+  expect(result1).toEqual(result2);
+
+  //testing if next + next + undo + undo equals the original automaton
+  core2.automaton.executeCommand((algorithm2.next()?.command as AutomatonEditCommand));
+  core2.automaton.executeCommand((algorithm2.next()?.command as AutomatonEditCommand));
+  algorithm2.undo();
+  algorithm2.undo();
+  expect(core2.automaton).toEqual(core.automaton);
+
+  //testing if next + undo works in the entire algorthm
+  for (let i = 0; i < algorithm.results!.length - 1; i++) {
+      core.automaton.executeCommand((algorithm.next()?.command as AutomatonEditCommand));
+      core2.automaton.executeCommand((algorithm2.next()?.command as AutomatonEditCommand));
+      expect(core2.automaton).toEqual(core.automaton);
+
+      core.automaton.executeCommand((algorithm.next()?.command as AutomatonEditCommand));
+      algorithm.undo();
+      expect(core2.automaton).toEqual(core.automaton);
+    }
+});


### PR DESCRIPTION
Tak je spravený druhý algoritmus a opäť mám aj testy. 

Zatiaľ je to urobené spôsobom, že edit comandy sa vykonávajú priamo na vstupnom automate a highlighty sú prázdne. Treba sa rozhodnúť či to chceme takto, alebo chceme aj v tomto prípade druhé okno s automatom, aby to bolo konzistentné s ostatnými algoritmami. Lebo teraz tam aj tak musím vytvárať zbytočne druhý core, ktorý nepoužívam, aby jeden argument vo funkcii nebol unused. Prerobiť to by nemal byť problém, len treba potom vyriešiť vizualizáciu počiatočného automatu v druhom okne.