### PR TITLE
Fojalka 28 automaton core grammar core highlight methods

### DIFF
--- a/src/core/automatonCore.ts
+++ b/src/core/automatonCore.ts
@@ -234,8 +234,8 @@ export class AutomatonCore implements IAutomatonCore {
     if (this.mode.mode !== Mode.VISUAL) {
       return new ErrorMessage("Operation is only permitted in visual mode.");
     }
-
-    return new ErrorMessage(`Not implemented ${ids}`);
+    this.visual.clearHighlights();
+    this.visual.highlightElements(ids);
   }
 
   containsWord(word: string[]) {

--- a/src/core/automatonCore.ts
+++ b/src/core/automatonCore.ts
@@ -112,8 +112,8 @@ export class AutomatonCore implements IAutomatonCore {
     // this does not use visitor (at least not yet) because the visitor does not accept position
     this.visual.addNode(id, position);
     // highlighting newly added node
-    this.visual.clearHighlights();
-    this.visual.highlightElements([id]);
+    // this.visual.clearHighlights();
+    // this.visual.highlightElements([id]);
   }
 
   removeState(id: string) {
@@ -196,8 +196,8 @@ export class AutomatonCore implements IAutomatonCore {
 
     command.accept(this.visitor);
     // highlighting newly added edge
-    this.visual.clearHighlights();
-    this.visual.highlightElements([edge.id]);
+    // this.visual.clearHighlights();
+    // this.visual.highlightElements([edge.id]);
   }
 
   removeEdge(from: string, to: string, id: string) {

--- a/src/core/automatonCore.ts
+++ b/src/core/automatonCore.ts
@@ -111,6 +111,9 @@ export class AutomatonCore implements IAutomatonCore {
 
     // this does not use visitor (at least not yet) because the visitor does not accept position
     this.visual.addNode(id, position);
+    // highlighting newly added node
+    this.visual.clearHighlights();
+    this.visual.highlightElements([id]);
   }
 
   removeState(id: string) {
@@ -192,6 +195,9 @@ export class AutomatonCore implements IAutomatonCore {
     }
 
     command.accept(this.visitor);
+    // highlighting newly added edge
+    this.visual.clearHighlights();
+    this.visual.highlightElements([edge.id]);
   }
 
   removeEdge(from: string, to: string, id: string) {

--- a/src/core/grammarCore.ts
+++ b/src/core/grammarCore.ts
@@ -72,6 +72,10 @@ export class GrammarCore implements IGrammarCore {
         return error;
       }
 
+      // highlighting newly added rules
+      this.visual.clearHighlights();
+      this.visual.highlight([rule.id]);
+
       command.accept(this.visitor);
 
     } catch (e: unknown) {
@@ -146,6 +150,9 @@ export class GrammarCore implements IGrammarCore {
       return error;
     }
 
+    // highlighting newly added non-terminals
+    this.visual.clearHighlights();
+    this.visual.highlight(nonTerminals);
     command.accept(this.visitor);
   }
 
@@ -176,6 +183,9 @@ export class GrammarCore implements IGrammarCore {
       return error;
     }
 
+    // highlighting newly added terminals
+    this.visual.clearHighlights();
+    this.visual.highlight(terminals);
     command.accept(this.visitor);
   }
 
@@ -239,7 +249,7 @@ export class GrammarCore implements IGrammarCore {
     }
 
     this.visual.clearHighlights();
-    this.visual.highlightRule(ids);
+    this.visual.highlight(ids);
   }
 
   simulateParsing(word: string[]) {

--- a/src/core/grammarCore.ts
+++ b/src/core/grammarCore.ts
@@ -13,7 +13,7 @@ export interface IGrammarCore {
   mode: ModeHolder;
   grammar: Grammar;
 
-  display: () => string;
+  display: () => React.ReactNode;
 
   addProductionRule: (inputNonTerminal: string, outputSymbols: string[]) => IErrorMessage | undefined
   editProductionRule: (id: string, inputNonTerminal: string, outputSymbols: string[]) => IErrorMessage | undefined;
@@ -220,7 +220,8 @@ export class GrammarCore implements IGrammarCore {
       return new ErrorMessage("Operation is only permitted in visual mode.");
     }
 
-    return new ErrorMessage(`Not implemented ${ids}`);
+    this.visual.clearHighlights();
+    this.visual.highlightRule(ids);
   }
 
   simulateParsing(word: string[]) {

--- a/src/core/grammarCore.ts
+++ b/src/core/grammarCore.ts
@@ -73,8 +73,8 @@ export class GrammarCore implements IGrammarCore {
       }
 
       // highlighting newly added rules
-      this.visual.clearHighlights();
-      this.visual.highlight([rule.id]);
+      // this.visual.clearHighlights();
+      // this.visual.highlight([rule.id]);
 
       command.accept(this.visitor);
 
@@ -151,8 +151,8 @@ export class GrammarCore implements IGrammarCore {
     }
 
     // highlighting newly added non-terminals
-    this.visual.clearHighlights();
-    this.visual.highlight(nonTerminals);
+    // this.visual.clearHighlights();
+    // this.visual.highlight(nonTerminals);
     command.accept(this.visitor);
   }
 
@@ -184,8 +184,8 @@ export class GrammarCore implements IGrammarCore {
     }
 
     // highlighting newly added terminals
-    this.visual.clearHighlights();
-    this.visual.highlight(terminals);
+    // this.visual.clearHighlights();
+    // this.visual.highlight(terminals);
     command.accept(this.visitor);
   }
 

--- a/src/core/grammarCore.ts
+++ b/src/core/grammarCore.ts
@@ -123,11 +123,20 @@ export class GrammarCore implements IGrammarCore {
     if (this.mode.mode !== Mode.EDIT) {
       return new ErrorMessage("Operation is only permitted in edit mode.");
     }
-    if (nonTerminals.some(symbol => symbol.trim().length === 0)) {
-      return new ErrorMessage("Nonterminal symbol must contain at least one non-whitespace character.");
-    }
-    if (nonTerminals.some(symbol => symbol.includes(" "))) {
-      return new ErrorMessage("Nonterminal symbol must not contain spaces.");
+    for (const symbol of nonTerminals) {
+      const trimmed = symbol.trim();
+
+      if (trimmed.length === 0) {
+        return new ErrorMessage("Nonterminal symbol must contain at least one non-whitespace character.");
+      }
+
+      if (trimmed.charAt(0) === "_") {
+        return new ErrorMessage("Nonterminal symbol cannot start with an underscore.");
+      }
+
+      if (trimmed.includes(" ")) {
+        return new ErrorMessage("Nonterminal symbol must not contain spaces.");
+      }
     }
 
     const command: GrammarEditCommand = new AddNonterminalsCommand(this.grammar, nonTerminals);
@@ -144,11 +153,20 @@ export class GrammarCore implements IGrammarCore {
     if (this.mode.mode !== Mode.EDIT) {
       return new ErrorMessage("Operation is only permitted in edit mode.");
     }
-    if (terminals.some(symbol => symbol.trim().length === 0)) {
-      return new ErrorMessage("Terminal symbol must contain at least one non-whitespace character.");
-    }
-    if (terminals.some(symbol => symbol.includes(" "))) {
-      return new ErrorMessage("Terminal symbol must not contain spaces.");
+    for (const symbol of terminals) {
+      const trimmed = symbol.trim();
+
+      if (trimmed.length === 0) {
+        return new ErrorMessage("Terminal symbol must contain at least one non-whitespace character.");
+      }
+
+      if (trimmed.charAt(0) === "_") {
+        return new ErrorMessage("Terminal symbol cannot start with an underscore.");
+      }
+
+      if (trimmed.includes(" ")) {
+        return new ErrorMessage("Terminal symbol must not contain spaces.");
+      }
     }
 
     const command: GrammarEditCommand = new AddTerminalsCommand(this.grammar, terminals);

--- a/src/engine/grammar/commands/edit.ts
+++ b/src/engine/grammar/commands/edit.ts
@@ -118,7 +118,7 @@ export class AddNonterminalsCommand extends GrammarEditCommand {
   }
 
   execute(): IErrorMessage | undefined {
-    for (const symbol in this.nonterminals) {
+    for (const symbol of this.nonterminals) {
       if (this.grammar.terminalSymbols.includes(symbol)) {
         return new ErrorMessage(`Cannot add nonterminal symbol ${symbol}: it is already present as a terminal symbol.`);
       }
@@ -149,7 +149,7 @@ export class AddTerminalsCommand extends GrammarEditCommand {
   }
 
   execute(): IErrorMessage | undefined {
-    for (const symbol in this.terminals) {
+    for (const symbol of this.terminals) {
       if (this.grammar.nonTerminalSymbols.includes(symbol)) {
         return new ErrorMessage(`Cannot add terminal symbol ${symbol}: it is already present as a nonterminal symbol.`);
       }

--- a/src/engine/grammar/commands/edit.ts
+++ b/src/engine/grammar/commands/edit.ts
@@ -122,6 +122,9 @@ export class AddNonterminalsCommand extends GrammarEditCommand {
       if (this.grammar.terminalSymbols.includes(symbol)) {
         return new ErrorMessage(`Cannot add nonterminal symbol ${symbol}: it is already present as a terminal symbol.`);
       }
+      if (this.grammar.nonTerminalSymbols.includes(symbol)) {
+        return new ErrorMessage(`Cannot add nonterminal symbol ${symbol}: it is already present.`);
+      }
       if (symbol === EPSILON) {
         return new ErrorMessage("Cannot add epsilon as nonterminal symbol.");
       }
@@ -152,6 +155,9 @@ export class AddTerminalsCommand extends GrammarEditCommand {
     for (const symbol of this.terminals) {
       if (this.grammar.nonTerminalSymbols.includes(symbol)) {
         return new ErrorMessage(`Cannot add terminal symbol ${symbol}: it is already present as a nonterminal symbol.`);
+      }
+      if (this.grammar.terminalSymbols.includes(symbol)) {
+        return new ErrorMessage(`Cannot add terminal symbol ${symbol}: it is already present.`);
       }
       if (symbol === EPSILON) {
         return new ErrorMessage("Cannot add epsilon as terminal symbol.");

--- a/src/engine/grammar/factories.ts
+++ b/src/engine/grammar/factories.ts
@@ -11,7 +11,7 @@ export abstract class IGrammarFactory {
 
   private production_rule_id_increment: number = 0;
   protected nextProductionRuleString(): string {
-    return `production_rule_${this.production_rule_id_increment++}`;
+    return `_production_rule_${this.production_rule_id_increment++}`;
   }
 }
 

--- a/src/engine/grammar/grammar.ts
+++ b/src/engine/grammar/grammar.ts
@@ -62,14 +62,12 @@ export class Grammar {
     return this.terminalSymbols.some(terminal => terminal === findTerminal);
   }
 
-  executeCommand(command: GrammarEditCommand): void {
-    const res = command.execute();
-    if (res === undefined) {
+  executeCommand(command: GrammarEditCommand): IErrorMessage | undefined {
+    const maybeErrorMessage = command.execute();
+    if (maybeErrorMessage === undefined) {
       this.commandHistory.push(command);
-    } else {
-      throw res;
     }
-
+    return maybeErrorMessage;
   }
   undo(): IErrorMessage | undefined {
     const command = this.commandHistory.pop();

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -8,3 +8,8 @@
     height: 100%;
     min-height: 100vh;
 }
+
+.highlight {
+    color: indianred;
+    font-weight: bold;
+}

--- a/src/ui/components/grammar-window/GrammarRepresentation.tsx
+++ b/src/ui/components/grammar-window/GrammarRepresentation.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./styles.css";
 
 interface GrammarRepresentationProps {
-  grammarRepr: string;
+  grammarRepr: React.ReactNode;
 }
 
 const GrammarRepresentation: React.FC<GrammarRepresentationProps> = ({ grammarRepr }) => {

--- a/src/ui/components/grammar-window/GrammarWindow.tsx
+++ b/src/ui/components/grammar-window/GrammarWindow.tsx
@@ -24,7 +24,7 @@ export const GrammarWindow: React.FC<GrammarWindowProps> = ({ grammarType }) => 
   const [newNonTerminal, setNewNonTerminal] = useState("");
   const [newTerminal, setNewTerminal] = useState("");
 
-  const [grammarRepr, setGrammarRepr] = useState("");
+  const [grammarRepr, setGrammarRepr] = useState<React.ReactNode>();
 
   // This method has to be called everytime a change is made to the grammar (to obtain the updated string repr.)
   const refreshRepr = () => {

--- a/src/visual/automatonVisual.ts
+++ b/src/visual/automatonVisual.ts
@@ -82,9 +82,7 @@ export class AutomatonVisual implements IAutomatonVisual {
   }
 
   addNode(id: string, position: { x: number; y: number }) {
-    this.clearHighlights();
     this.cy?.add({ group: "nodes", data: { id }, position });
-    this.highlightElements([id]);
   }
 
   removeNode(id: string) {
@@ -107,9 +105,7 @@ export class AutomatonVisual implements IAutomatonVisual {
   }
 
   addEdge(id: string, from: string, to: string, label: string) {
-    this.clearHighlights();
     this.cy?.add({ group: "edges", data: { id, source: from, target: to, label } });
-    this.highlightElements([id]);
   }
 
   // TODO

--- a/src/visual/automatonVisual.ts
+++ b/src/visual/automatonVisual.ts
@@ -82,7 +82,9 @@ export class AutomatonVisual implements IAutomatonVisual {
   }
 
   addNode(id: string, position: { x: number; y: number }) {
+    this.clearHighlights();
     this.cy?.add({ group: "nodes", data: { id }, position });
+    this.highlightElements([id]);
   }
 
   removeNode(id: string) {
@@ -105,7 +107,9 @@ export class AutomatonVisual implements IAutomatonVisual {
   }
 
   addEdge(id: string, from: string, to: string, label: string) {
+    this.clearHighlights();
     this.cy?.add({ group: "edges", data: { id, source: from, target: to, label } });
+    this.highlightElements([id]);
   }
 
   // TODO
@@ -117,13 +121,37 @@ export class AutomatonVisual implements IAutomatonVisual {
     this.cy?.remove(`edge#${id}`);
   }
 
-  // TODO
   highlightElements(ids: string[]) {
-    console.log(ids);
-  };
+    for (const id of ids) {
+      const element = this.cy?.getElementById(id);
+      if (element && element.nonempty()) {
+        if (id.startsWith("_")) {
+          // It's an edge
+          element.style({
+            "line-color": "salmon",
+            "target-arrow-color": "salmon",
+          });
+        } else {
+          // It's a node
+          element.style({
+            "background-color": "salmon",
+          });
+        }
+      } else {
+        console.warn(`Element with id "${id}" not found.`);
+      }
+    }
+  }
 
-  // TODO
   clearHighlights() {
-    return;
+    this.cy?.nodes().forEach(node => {
+      node.style({ "background-color": "#666" }); // your default node color
+    });
+    this.cy?.edges().forEach(edge => {
+      edge.style({
+        "line-color": "#ccc",
+        "target-arrow-color": "#ccc",
+      });
+    });
   }
 }

--- a/src/visual/grammarVisual.tsx
+++ b/src/visual/grammarVisual.tsx
@@ -66,12 +66,12 @@ export class GrammarVisual implements IGrammarVisual {
     const ts = this.grammar.terminalSymbols.join(", ");
     const start = this.grammar.initialNonTerminalSymbol;
 
-    const ruleElements = this.grammar.productionRules.map((rule, index) => {
+    const ruleElements = this.grammar.productionRules.map((rule) => {
       const ruleStr = `${rule.inputNonTerminal} → ${rule.outputSymbols.join(" ")}`;
       const isHighlighted = this.highlightedRuleIds.has(rule.id); // or based on index
 
       return (
-        <div key={index} className={isHighlighted ? "highlight" : ""}>
+        <div key={`g-rule-visual-${rule.id}`} className={isHighlighted ? "highlight" : ""}>
           {ruleStr}
         </div>
       );

--- a/src/visual/grammarVisual.tsx
+++ b/src/visual/grammarVisual.tsx
@@ -1,34 +1,40 @@
 import { Kind } from "../core/core";
 import { Grammar } from "../engine/grammar/grammar";
+import { JSX } from "react";
 
 // for now this only converts grammar to string, which can be put into HTML
 // TODO actual grammar visualisation
 export interface IGrammarVisual {
   kind: Kind.GRAMMAR
   setGrammar: (grammar: Grammar) => void;
-  display: () => string;
+  display: () => React.ReactNode;
   storeRuleId: (id: string) => void;
   removeRuleId: (id: string) => void;
   getRuleIdByIndex: (index: number) => string | undefined;
   refresh: () => void;
+  highlightRule: (ids: string[]) => void;
+  clearHighlights: () => void;
 }
 
 export class GrammarVisual implements IGrammarVisual {
   kind = Kind.GRAMMAR as const;
   grammar?: Grammar;
-  representation: string = "";
+  representation: JSX.Element = <></>;
   existingRuleIds: string[] = [];
+  highlightedRuleIds: Set<string> = new Set();
 
   setGrammar(grammar: Grammar) {
     this.grammar = grammar;
   }
 
-  display(): string {
+  display(): React.ReactNode {
     return this.representation;
   }
 
   storeRuleId(id: string) {
+    this.clearHighlights();
     this.existingRuleIds.push(id);
+    this.highlightRule([id]);
   }
 
   removeRuleId(id: string) {
@@ -39,25 +45,46 @@ export class GrammarVisual implements IGrammarVisual {
     return this.existingRuleIds?.[index];
   }
 
+  highlightRule(ids: string[]) {
+    for (const id of ids) {
+      this.highlightedRuleIds.add(id);
+    }
+  }
+
+  clearHighlights() {
+    this.highlightedRuleIds.clear();
+  }
+
   // refresh representation according to grammar
   refresh() {
     if (!this.grammar) {
-      this.representation = "No grammar set.";
+      this.representation = <>No grammar set.</>;
       return;
     }
 
     const nts = this.grammar.nonTerminalSymbols.join(", ");
     const ts = this.grammar.terminalSymbols.join(", ");
     const start = this.grammar.initialNonTerminalSymbol;
-    const rules = this.grammar.productionRules
-      .map(rule => `${rule.inputNonTerminal} → ${rule.outputSymbols.join(" ")}`)
-      .join("\n");
+
+    const ruleElements = this.grammar.productionRules.map((rule, index) => {
+      const ruleStr = `${rule.inputNonTerminal} → ${rule.outputSymbols.join(" ")}`;
+      const isHighlighted = this.highlightedRuleIds.has(rule.id); // or based on index
+
+      return (
+        <div key={index} className={isHighlighted ? "highlight" : ""}>
+          {ruleStr}
+        </div>
+      );
+    });
 
     this.representation =
-      `Non-terminals: ${nts}\n` +
-      `Terminals: ${ts}\n` +
-      `Initial symbol: ${start}\n` +
-      `Production Rules:\n${rules}`;
+        <div>
+          <div><strong>Non-terminals:</strong> {nts}</div>
+          <div><strong>Terminals:</strong> {ts}</div>
+          <div><strong>Initial symbol:</strong> {start}</div>
+          <div><strong>Production Rules:</strong></div>
+          {ruleElements}
+        </div>
+    ;
   }
-
 }

--- a/tests/grammar.test.ts
+++ b/tests/grammar.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { AbstractGrammarFactory } from "../src/engine/grammar/factories.ts";
 import { AddProductionRuleCommand } from "../src/engine/grammar/commands/edit.ts";
 import { GrammarType } from "../src/engine/grammar/grammar.ts";
+import { ErrorMessage } from "../src/engine/common.ts";
 
 test("Regular grammar test", () => {
   const agf = new AbstractGrammarFactory(GrammarType.REGULAR);
@@ -18,7 +19,9 @@ test("Regular grammar test", () => {
   console.log(grammar);
 
   // series of wrong operations
-  expect(() => grammar.executeCommand(new AddProductionRuleCommand(grammar, addProductionRuleTwo))).toThrow();
+  const result = grammar.executeCommand(new AddProductionRuleCommand(grammar, addProductionRuleTwo));
+  expect(result).toBeInstanceOf(ErrorMessage);
+  expect(result.details).toBe("Cannot add production rule: S -> abaS: it is already present.");
   const addNonCFProductionRule = () => {
     grammar.executeCommand(new AddProductionRuleCommand(grammar, agf.createProductionRule("S", ["a", "S", "a"], grammar)));
   };


### PR DESCRIPTION
Added highlighting functionality (highligh() and clearHighlights() functions) to both automaton and grammar visuals. Along the way fixed minor issues:
- error propagation in grammar executeCommand(), return instead of throw
- grammar core now forbids grammar symbols to start with underscore (used to distinguish production rule IDs), may have potentially caused problems in grammar to automaton algorithm
- commands for adding symbols to grammar now properly check if a symbol exists as both terminal or nonterminal

To demo the highlighting, uncomment lines under `// highlighting newly added ...` in automaton and grammar core: 
![image](https://github.com/user-attachments/assets/18e18c54-2199-454c-9c11-3d3b647ac756)
Every newly added element will be colored.
